### PR TITLE
Fixed firebase import warning

### DIFF
--- a/src/vars/firebase.js
+++ b/src/vars/firebase.js
@@ -1,8 +1,9 @@
-import firebase from 'firebase';
-import {initializeApp} from 'firebase/app';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/firestore';
 import 'firebase/auth';
 
-const firebaseApp = initializeApp({
+const firebaseApp = firebase.initializeApp({
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: "meetup-react-penang.web.app",
   databaseURL: "https://react-penang.firebaseio.com",

--- a/src/vars/firebase.js
+++ b/src/vars/firebase.js
@@ -1,7 +1,6 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
-import 'firebase/auth';
 
 const firebaseApp = firebase.initializeApp({
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,


### PR DESCRIPTION
We should always import only the core package (`import firebase from 'firebase/app'`), then we only import those packages that we need.